### PR TITLE
Fix : 카카오로그인 프로필이미지 재수정

### DIFF
--- a/src/main/java/com/project/danim_be/member/service/SocialService.java
+++ b/src/main/java/com/project/danim_be/member/service/SocialService.java
@@ -171,8 +171,9 @@ public class SocialService {
             }
             case "KAKAO" -> {
                 email = userInfoData.get("kakao_account").get("email").asText();
-                if(userInfoData.get("kakao_account").get("profile_image_needs_agreement").asText().equals("false")) {
-                    userImage = userInfoData.get("kakao_account").get("profile").get("profile_image_url").asText();
+                JsonNode userProfile = userInfoData.get("kakao_account").get("profile");
+                if(userProfile != null && userInfoData.get("kakao_account").get("profile_image_needs_agreement").asText().equals("false")){
+                    userImage = userProfile.get("profile_image_url").asText();
                 } else {
                     userImage = "https://danimdata.s3.ap-northeast-2.amazonaws.com/avatar.png";
                 }


### PR DESCRIPTION
이미지 제공 비동의시 profile_image_needs_agreement 값이 true로 들어오지 않고 false로 들어와 조건을 타고 nullPointerException 발생

json 객체가 profile을 가지고 있는지 여부로 조건 변경